### PR TITLE
Fix issue with build crashing at "mysql_install_db" and "npm install"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #FROM mhart/alpine-node
-FROM java:openjdk-8u111-jdk
+FROM openjdk:8-jdk-stretch
 LABEL maintainer "jonas.koenning@rwth-aachen.de"
 
 # Java Version and other ENV
@@ -22,7 +22,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update
 
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get install -y --no-install-recommends supervisor screen nodejs python g++ git ant maven make bash
 
 RUN npm install -g http-server bower grunt-cli grunt
@@ -65,8 +65,7 @@ RUN cd / && \
 	wget http://mirrors.jenkins.io/war-stable/latest/jenkins.war && \
 	mkdir /root/.jenkins && \
 	touch /root/.jenkins/jenkins.install.InstallUtil.lastExecVersion && \
-	echo "2.0" >> /root/.jenkins/jenkins.install.InstallUtil.lastExecVersion && \
-	cp /opt/jenkins/configs/config.xml /root/.jenkins/
+	echo "2.0" >> /root/.jenkins/jenkins.install.InstallUtil.lastExecVersion
 
 ######### ROLE ##########
 #RUN mkdir source && \


### PR DESCRIPTION
*mysql_install_db* crashes with the following error:
```
FATAL ERROR: Neither host '<container-id>' nor 'localhost' could be look up with /usr/bin/resolveip
```
The issue here is that */usr/bin/resolveip* does not even exist. It is a deprecated tool that usually comes bundeled with MySQL. I upgraded the base image and the error went away. 

I also upgraded nodejs to version 10 because else ```npm install``` inside RoleApiJS would fail.